### PR TITLE
Merge Collapser

### DIFF
--- a/src/collapser.c
+++ b/src/collapser.c
@@ -1,0 +1,18 @@
+#include "collapser.h"
+
+coords find_lowest_entropy(matrix* cells, size_t num_tiles) {
+  coords lowest_loc = {.x = 0, .y = 0};
+  size_t lowest_entropy = num_tiles;
+  //NOLINTBEGIN(readability-identifier-length)
+  for (size_t x = 0; x < cells->width; x++) {
+    for (size_t y = 0; y < cells->height; y++) {
+      if (cells->array[x][y].entropy < lowest_entropy) {
+        lowest_loc.x = x;
+        lowest_loc.y = y;
+      }
+    }
+  }
+
+  //NOLINTEND(readability-identifier-length)
+  return lowest_loc;
+}

--- a/src/collapser.c
+++ b/src/collapser.c
@@ -3,16 +3,14 @@
 coords find_lowest_entropy(matrix* cells, size_t num_tiles) {
   coords lowest_loc = {.x = 0, .y = 0};
   size_t lowest_entropy = num_tiles;
-  //NOLINTBEGIN(readability-identifier-length)
-  for (size_t x = 0; x < cells->width; x++) {
-    for (size_t y = 0; y < cells->height; y++) {
-      if (cells->array[x][y].entropy < lowest_entropy) {
-        lowest_loc.x = x;
-        lowest_loc.y = y;
+  for (size_t col = 0; col < cells->width; col++) {
+    for (size_t row = 0; row < cells->height; row++) {
+      if (cells->array[col][row].entropy < lowest_entropy) {
+        lowest_loc.x = col;
+        lowest_loc.y = row;
       }
     }
   }
 
-  //NOLINTEND(readability-identifier-length)
   return lowest_loc;
 }

--- a/src/collapser.h
+++ b/src/collapser.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "datatypes.h"
+#include "helpers.h"
+
+coords find_lowest_entropy(matrix* cells, size_t num_tiles);
+
+void update_neighbors(matrix* cells, coords loc);

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -34,7 +34,7 @@ typedef struct {
 
 typedef struct {
 
-  char* img_name = "";
+  char* img_name;
   int rotation;
   edge_t edges;
 } tile;

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -8,14 +8,14 @@
 
 typedef struct {
 
-  int x;
-  int y;
+  size_t x;
+  size_t y;
 
 } coords;
 
 typedef struct {
 
-  int entropy;
+  size_t entropy;
 
 } cell;
 
@@ -35,7 +35,7 @@ typedef struct {
 typedef struct {
 
   char* img_name;
-  int rotation;
+  size_t rotation;
   edge_t edges;
 } tile;
 
@@ -60,7 +60,7 @@ cell* make_cell(tile* tiles);
 
 int free_cell(cell* cellp);
 
-tile* make_tile(FILE* image_file, int rotation, edge_t* edges_);
+tile* make_tile(FILE* image_file, size_t rotation, edge_t* edges_);
 // check if this is the correct way to change 
 
 int free_tile(tile*);


### PR DESCRIPTION
Function signatures for collapser functions.
Change `int` -> `size_t` for numbers that are actually sizes (coordinates, counters, etc.)
Fix datatypes.h definition error
Implement find_lowest_entropy function